### PR TITLE
Android fix: Fix ClassCastException on `index` parameter of `getMessagesBefore`

### DIFF
--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessagesMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessagesMethods.kt
@@ -135,7 +135,7 @@ object MessagesMethods {
     }
 
     fun getMessagesBefore(call: MethodCall, result: MethodChannel.Result) {
-        val index = call.argument<Long>("index")
+        val index = call.argument<Int>("index")?.toLong()
                 ?: return result.error("ERROR", "Missing 'index'", null)
         val count = call.argument<Int>("count")
                 ?: return result.error("ERROR", "Missing 'count'", null)


### PR DESCRIPTION
This commit fixes a ClassCastException that occurs when passing the `index` parameter to the `getMessagesBefore` method on Android.