### PR TITLE
IOS: Update ChatListener to match Protocol

### DIFF
--- a/ios/Classes/Listeners/ChatListener.swift
+++ b/ios/Classes/Listeners/ChatListener.swift
@@ -19,20 +19,15 @@ public class ChatListener: NSObject, TwilioConversationsClientDelegate {
         sendEvent("addedToChannelNotification", data: ["channelSid": channelSid])
     }
 
-    // onChannelAdded / onChannelInvited
-    public func conversationsClient(_ client: TwilioConversationsClient, channelAdded channel: TCHConversation) {
-        if channel.status == TCHConversationStatus.joined {
-            SwiftTwilioConversationsPlugin.debug("ChatListener.onChannelJoined => channelSid is \(String(describing: channel.sid))'")
-            sendEvent("channelJoined", data: ["channel": Mapper.channelToDict(channel) as Any])
-        } else {
-            SwiftTwilioConversationsPlugin.debug("ChatListener.onChannelAdded => channelSid is \(String(describing: channel.sid))'")
-            sendEvent("channelAdded", data: ["channel": Mapper.channelToDict(channel) as Any])
-        }
+    // onChannelAdded
+    public func conversationsClient(_ client: TwilioConversationsClient, conversationAdded channel: TCHConversation) {
+        SwiftTwilioConversationsPlugin.debug("ChatListener.conversationAdded => channelSid is \(String(describing: channel.sid))'")
+        sendEvent("channelAdded", data: ["channel": Mapper.channelToDict(channel) as Any])
     }
 
     // onChannelDeleted
-    public func conversationsClient(_ client: TwilioConversationsClient, channelDeleted channel: TCHConversation) {
-        SwiftTwilioConversationsPlugin.debug("ChatListener.onChannelDeleted => channelSid is \(String(describing: channel.sid))'")
+    public func conversationsClient(_ client: TwilioConversationsClient, conversationDeleted channel: TCHConversation) {
+        SwiftTwilioConversationsPlugin.debug("ChatListener.conversationDeleted => channelSid is \(String(describing: channel.sid))'")
         sendEvent("channelDeleted", data: ["channel": Mapper.channelToDict(channel) as Any])
     }
 

--- a/lib/src/chat_client.dart
+++ b/lib/src/chat_client.dart
@@ -102,12 +102,6 @@ class ChatClient {
   /// Called when the current user was invited to a channel, channel status is [ChannelStatus.INVITED].
   Stream<Channel>? onChannelInvited;
 
-  final StreamController<Channel> _onChannelJoinedCtrl =
-      StreamController<Channel>.broadcast();
-
-  /// Called when the current user either joined or was added into a channel, channel status is [ChannelStatus.JOINED].
-  Stream<Channel>? onChannelJoined;
-
   final StreamController<Channel> _onChannelSynchronizationChangeCtrl =
       StreamController<Channel>.broadcast();
 
@@ -235,7 +229,6 @@ class ChatClient {
     onChannelAdded = _onChannelAddedCtrl.stream;
     onChannelDeleted = _onChannelDeletedCtrl.stream;
     onChannelInvited = _onChannelInvitedCtrl.stream;
-    onChannelJoined = _onChannelJoinedCtrl.stream;
     onChannelSynchronizationChange = _onChannelSynchronizationChangeCtrl.stream;
     onChannelUpdated = _onChannelUpdatedCtrl.stream;
     onClientSynchronization = _onClientSynchronizationCtrl.stream;
@@ -432,11 +425,6 @@ class ChatClient {
         assert(channelMap != null);
         Channels._updateChannelFromMap(channelMap!);
         _onChannelInvitedCtrl.add(Channels._channelsMap[channelMap['sid']]!);
-        break;
-      case 'channelJoined':
-        assert(channelMap != null);
-        Channels._updateChannelFromMap(channelMap!);
-        _onChannelJoinedCtrl.add(Channels._channelsMap[channelMap['sid']]!);
         break;
       case 'channelSynchronizationChange':
         assert(channelMap != null);


### PR DESCRIPTION
The `ChatListener` was not notified about new channels on IOS.  Updated the methods to match the [TwilioConversationsClientDelegate Protocol](https://sdk.twilio.com/ios/conversations/releases/3.1.0/docs/Protocols/TwilioConversationsClientDelegate.html) where the methods are `conversationAdded` and `conversationDeleted`. 

Additionally I removed the `channelJoined` event to match the implementation of Android.  This is a breaking change and the `channelAdded` event should be used instead.  The client can evaluate the channel status to determine if it was joined. 