### PR TITLE
Fix MissingPluginException on Android

### DIFF
--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/TwilioConversationsPlugin.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/TwilioConversationsPlugin.kt
@@ -163,6 +163,8 @@ class TwilioConversationsPlugin : FlutterPlugin {
         loggingChannel.setStreamHandler(null)
         notificationChannel.setStreamHandler(null)
         mediaProgressChannel.setStreamHandler(null)
+        channelChannels.clear()
+        channelListeners.clear()
         initialized = false
     }
 


### PR DESCRIPTION
Clear `channelChannels` and `channelListeners` in `onDetachedFromEngine`
Fix for #11