### PR TITLE
Pull out static values that were causing exceptions when launching from a background Firebase message

### DIFF
--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/PluginHandler.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/PluginHandler.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import com.twilio.conversations.CallbackListener
 import com.twilio.conversations.ConversationsClient
 import com.twilio.util.ErrorInfo
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -20,27 +21,26 @@ import twilio.flutter.twilio_conversations.methods.MessagesMethods
 import twilio.flutter.twilio_conversations.methods.UserMethods
 import twilio.flutter.twilio_conversations.methods.UsersMethods
 
-class PluginHandler(private val applicationContext: Context) : MethodCallHandler {
-
-    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {
+class PluginHandler(private val pluginInstance: TwilioConversationsPlugin, private val applicationContext: Context) : MethodCallHandler {
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         Log.d("TwilioInfo", "TwilioConversationsPlugin.onMethodCall => received ${call.method}")
         if (call.method != "cancel" && call.method != "listen") {
             when (call.method) {
                 "debug" -> debug(call, result)
                 "create" -> create(call, result)
-                "registerForNotification" -> TwilioConversationsPlugin.instance.registerForNotification(call, result)
-                "unregisterForNotification" -> TwilioConversationsPlugin.instance.unregisterForNotification(call, result)
-                "handleReceivedNotification" -> TwilioConversationsPlugin.instance.handleReceivedNotification(call, result)
+                "registerForNotification" -> pluginInstance.registerForNotification(call, result)
+                "unregisterForNotification" -> pluginInstance.unregisterForNotification(call, result)
+                "handleReceivedNotification" -> pluginInstance.handleReceivedNotification(call, result)
 
                 "ChatClient#updateToken" -> ChatClientMethods.updateToken(call, result)
                 "ChatClient#shutdown" -> ChatClientMethods.shutdown(call, result)
-    
+
                 "User#unsubscribe" -> UserMethods.unsubscribe(call, result)
-    
+
                 "Users#getChannelUserDescriptors" -> UsersMethods.getChannelUserDescriptors(call, result)
                 "Users#getUserDescriptor" -> UsersMethods.getUserDescriptor(call, result)
                 "Users#getAndSubscribeUser" -> UsersMethods.getAndSubscribeUser(call, result)
-    
+
                 "Channel#join" -> ChannelMethods.join(call, result)
                 "Channel#leave" -> ChannelMethods.leave(call, result)
                 "Channel#typing" -> ChannelMethods.typing(call, result)
@@ -55,27 +55,27 @@ class PluginHandler(private val applicationContext: Context) : MethodCallHandler
                 "Channel#setNotificationLevel" -> ChannelMethods.setNotificationLevel(call, result)
                 "Channel#getUniqueName" -> ChannelMethods.getUniqueName(call, result)
                 "Channel#setUniqueName" -> ChannelMethods.setUniqueName(call, result)
-    
-                "Channels#getChannel" -> ChannelsMethods.getChannel(call, result)
+
+                "Channels#getChannel" -> ChannelsMethods.getChannel(pluginInstance, call, result)
                 "Channels#getPublicChannelsList" -> ChannelsMethods.getPublicChannelsList(call, result)
                 "Channels#getUserChannelsList" -> ChannelsMethods.getUserChannelsList(call, result)
-                "Channels#createChannel" -> ChannelsMethods.createChannel(call, result)
+                "Channels#createChannel" -> ChannelsMethods.createChannel(pluginInstance, call, result)
 
                 "Member#getUserDescriptor" -> MemberMethods.getUserDescriptor(call, result)
                 "Member#getAndSubscribeUser" -> MemberMethods.getAndSubscribeUser(call, result)
                 "Member#setAttributes" -> MemberMethods.setAttributes(call, result)
-    
+
                 "Members#getMembersList" -> MembersMethods.getMembersList(call, result)
                 "Members#getMember" -> MembersMethods.getMember(call, result)
                 "Members#addByIdentity" -> MembersMethods.addByIdentity(call, result)
                 "Members#inviteByIdentity" -> MembersMethods.inviteByIdentity(call, result)
                 "Members#removeByIdentity" -> MembersMethods.removeByIdentity(call, result)
-    
+
                 "Message#updateMessageBody" -> MessageMethods.updateMessageBody(call, result)
                 "Message#setAttributes" -> MessageMethods.setAttributes(call, result)
                 "Message#getMedia" -> MessageMethods.getMedia(call, result)
-    
-                "Messages#sendMessage" -> MessagesMethods.sendMessage(call, result)
+
+                "Messages#sendMessage" -> MessagesMethods.sendMessage(pluginInstance, call, result)
                 "Messages#removeMessage" -> MessagesMethods.removeMessage(call, result)
                 "Messages#getMessagesBefore" -> MessagesMethods.getMessagesBefore(call, result)
                 "Messages#getMessagesAfter" -> MessagesMethods.getMessagesAfter(call, result)
@@ -85,7 +85,7 @@ class PluginHandler(private val applicationContext: Context) : MethodCallHandler
                 "Messages#advanceLastReadMessageIndexWithResult" -> MessagesMethods.advanceLastReadMessageIndexWithResult(call, result)
                 "Messages#setAllMessagesReadWithResult" -> MessagesMethods.setAllMessagesReadWithResult(call, result)
                 "Messages#setNoMessagesReadWithResult" -> MessagesMethods.setNoMessagesReadWithResult(call, result)
-    
+
                 else -> result.notImplemented()
             }
         }
@@ -99,56 +99,78 @@ class PluginHandler(private val applicationContext: Context) : MethodCallHandler
         if (token == null) {
             return result.error("ERROR", "Missing token", null)
         }
+
         if (propertiesObj == null) {
             return result.error("ERROR", "Missing properties", null)
         }
 
+        val callRegion = propertiesObj["region"] as String?
+        val callDeferCA = propertiesObj["deferCA"] as Boolean?
+
+
+        val currentChatClient = TwilioConversationsPlugin.chatClient
+        val currentChatClientRegion = TwilioConversationsPlugin.chatClientRegion
+        val currentChatClientDeferCA = TwilioConversationsPlugin.chatClientDeferCA
+
         try {
-            if (TwilioConversationsPlugin.chatClient == null) {
+            if (currentChatClient == null) {
                 Log.d("TwilioInfo", "TwilioConversationsPlugin.create => making a fresh ChatClient")
             } else {
-                Log.d("TwilioInfo", "TwilioConversationsPlugin.create => ChatClient is already set, overriding")
-                TwilioConversationsPlugin.chatClient = null
-                Log.d("TwilioInfo", "TwilioConversationsPlugin.create => ChatClient is set to null")
+                Log.w("TwilioInfo", "TwilioConversationsPlugin.create => ChatClient is already exists.")
+                if (callRegion != currentChatClientRegion) {
+                    result.error("ERROR", "ChatClient already exists with a different region", null)
+                    return
+                } else if (callDeferCA != currentChatClientDeferCA) {
+                    result.error("ERROR", "ChatClient already exists with a different deferCA", null)
+                    return
+                }
             }
-                val propertiesBuilder = ConversationsClient.Properties.newBuilder()
-                if (propertiesObj["region"] != null) {
-                    Log.d("TwilioInfo", "TwilioConversationsPlugin.create => setting Properties.region to '${propertiesObj["region"]}'")
-                    propertiesBuilder.setRegion(propertiesObj["region"] as String)
-                }
-    
-                if (propertiesObj["deferCA"] != null) {
-                    Log.d("TwilioInfo", "TwilioConversationsPlugin.create => setting Properties.setDeferCertificateTrustToPlatform to '${propertiesObj["deferCA"]}'")
-                    propertiesBuilder.setDeferCertificateTrustToPlatform(propertiesObj["deferCA"] as Boolean)
-                }
-    
-                TwilioConversationsPlugin.chatListener = ChatListener(propertiesBuilder.createProperties())
-    
-                ConversationsClient.create(applicationContext, token, TwilioConversationsPlugin.chatListener.properties, object : CallbackListener<ConversationsClient> {
-                    override fun onSuccess(chatClient: ConversationsClient) {
-                        if (TwilioConversationsPlugin.chatClient == null) {
-                            Log.d("Twilio init success", "TwilioConversationsPlugin.create => ChatClient.create onSuccess: myIdentity is '${chatClient.myIdentity}'")
-                            try {
-                                TwilioConversationsPlugin.chatClient = chatClient
-                                val chatClientMap = Mapper.chatClientToMap(chatClient)
-                                result.success(chatClientMap)
-                            } catch (e: Exception) {
-                                Log.d("TwilioInfo", "TwilioConversationsPlugin.create => ChatClient.create onSuccess: failed to give result")
-                                Log.d("Twilio error", "TwilioConversationsPlugin.create => ChatClient.create onSuccess: failed to give result: $e : $chatClient : ${Mapper.chatClientToMap(chatClient)}")
-                                result.error("$e", "Failed to map chatClient", null)
-                            }
-                        }
-                    }
 
-                    override fun onError(errorInfo: ErrorInfo) {
-                            try {
-                                with(TwilioConversationsPlugin) { debug("TwilioConversationsPlugin.create => ChatClient.create onError: $errorInfo") }
-                                result.error("${errorInfo.code}", errorInfo.message, errorInfo.status)
-                            } catch (e1: Exception) {
-                                Log.d("TwilioInfo", "TwilioConversationsPlugin.create => ChatClient.create error: failed to send result of onError: $e1")
-                            }
+            val propertiesBuilder = ConversationsClient.Properties.newBuilder()
+            if (callRegion != null) {
+                Log.d("TwilioInfo", "TwilioConversationsPlugin.create => setting Properties.region to '${callRegion}'")
+                propertiesBuilder.setRegion(callRegion)
+            }
+
+            if (callDeferCA != null) {
+                Log.d("TwilioInfo", "TwilioConversationsPlugin.create => setting Properties.setDeferCertificateTrustToPlatform to '${callDeferCA}'")
+                propertiesBuilder.setDeferCertificateTrustToPlatform(callDeferCA)
+            }
+
+            pluginInstance.chatListener = ChatListener(pluginInstance, propertiesBuilder.createProperties())
+
+            if (currentChatClient != null) {
+                val chatClientMap = Mapper.chatClientToMap(pluginInstance, currentChatClient)
+                result.success(chatClientMap)
+                return
+            }
+
+            ConversationsClient.create(applicationContext, token, pluginInstance.chatListener.properties, object : CallbackListener<ConversationsClient> {
+                override fun onSuccess(chatClient: ConversationsClient) {
+                    Log.d("Twilio init success", "TwilioConversationsPlugin.create => ChatClient.create onSuccess: myIdentity is '${chatClient.myIdentity}'")
+                    try {
+                        TwilioConversationsPlugin.chatClient = chatClient
+                        TwilioConversationsPlugin.chatClientRegion = callRegion
+                        TwilioConversationsPlugin.chatClientDeferCA = callDeferCA
+
+                        val chatClientMap = Mapper.chatClientToMap(pluginInstance, chatClient)
+                        result.success(chatClientMap)
+                    } catch (e: Exception) {
+                        Log.d("TwilioInfo", "TwilioConversationsPlugin.create => ChatClient.create onSuccess: failed to give result")
+                        Log.d("Twilio error", "TwilioConversationsPlugin.create => ChatClient.create onSuccess: failed to give result: $e : $chatClient : ${Mapper.chatClientToMap(pluginInstance, chatClient)}")
+                        result.error("$e", "Failed to map chatClient", null)
                     }
-                })
+                }
+
+                override fun onError(errorInfo: ErrorInfo) {
+                        try {
+                            with(pluginInstance) { debug("TwilioConversationsPlugin.create => ChatClient.create onError: $errorInfo") }
+                            result.error("${errorInfo.code}", errorInfo.message, errorInfo.status)
+                        } catch (e1: Exception) {
+                            Log.d("TwilioInfo", "TwilioConversationsPlugin.create => ChatClient.create error: failed to send result of onError: $e1")
+                        }
+                }
+            })
         } catch (e: Exception) {
             result.error("ERROR", e.toString(), e)
         }
@@ -163,7 +185,7 @@ class PluginHandler(private val applicationContext: Context) : MethodCallHandler
         }
 
         if (enableNative != null) {
-            TwilioConversationsPlugin.nativeDebug = enableNative
+            pluginInstance.nativeDebug = enableNative
             result.success(enableNative)
         } else {
             result.error("MISSING_PARAMS", "Missing 'native' parameter", null)

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/ChannelListener.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/ChannelListener.kt
@@ -6,8 +6,9 @@ import io.flutter.plugin.common.EventChannel
 import twilio.flutter.twilio_conversations.Mapper
 import com.twilio.util.ErrorInfo
 import android.util.Log
+import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 
-class ChannelListener(private val events: EventChannel.EventSink) : TwilioChannelListener {
+class ChannelListener(private val pluginInstance: TwilioConversationsPlugin, private val events: EventChannel.EventSink) : TwilioChannelListener {
     override fun onMessageAdded(message: Message) {
         Log.d("TwilioInfo", "ChannelListener.onMessageAdded => messageSid = ${message.sid}")
         sendEvent("messageAdded", mapOf("message" to Mapper.messageToMap(message)))
@@ -54,17 +55,17 @@ class ChannelListener(private val events: EventChannel.EventSink) : TwilioChanne
 
     override fun onTypingStarted(channel: Conversation, member: Participant) {
         Log.d("TwilioInfo", "ChannelListener.onTypingStarted => channelSid = ${channel.sid}, memberSid = ${member.sid}")
-        sendEvent("typingStarted", mapOf("channel" to Mapper.channelToMap(channel), "member" to Mapper.memberToMap(member)))
+        sendEvent("typingStarted", mapOf("channel" to Mapper.channelToMap(pluginInstance, channel), "member" to Mapper.memberToMap(member)))
     }
 
     override fun onTypingEnded(channel: Conversation, member: Participant) {
         Log.d("TwilioInfo", "ChannelListener.onTypingEnded => channelSid = ${channel.sid}, memberSid = ${member.sid}")
-        sendEvent("typingEnded", mapOf("channel" to Mapper.channelToMap(channel), "member" to Mapper.memberToMap(member)))
+        sendEvent("typingEnded", mapOf("channel" to Mapper.channelToMap(pluginInstance, channel), "member" to Mapper.memberToMap(member)))
     }
 
     override fun onSynchronizationChanged(channel: Conversation) {
         Log.d("TwilioInfo", "ChannelListener.onSynchronizationChanged => channelSid = ${channel.sid}")
-        sendEvent("synchronizationChanged", mapOf("channel" to Mapper.channelToMap(channel)))
+        sendEvent("synchronizationChanged", mapOf("channel" to Mapper.channelToMap(pluginInstance, channel)))
     }
 
     private fun sendEvent(name: String, data: Any?, e: ErrorInfo? = null) {

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/ChatListener.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/ChatListener.kt
@@ -5,8 +5,9 @@ import io.flutter.plugin.common.EventChannel
 import twilio.flutter.twilio_conversations.Mapper
 import com.twilio.util.ErrorInfo
 import android.util.Log
+import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 
-class ChatListener(val properties: ConversationsClient.Properties) : ConversationsClientListener {
+class ChatListener(private val pluginInstance: TwilioConversationsPlugin, val properties: ConversationsClient.Properties) : ConversationsClientListener {
     var events: EventChannel.EventSink? = null
 
     override fun onClientSynchronization(synchronizationStatus: ConversationsClient.SynchronizationStatus) {
@@ -16,7 +17,7 @@ class ChatListener(val properties: ConversationsClient.Properties) : Conversatio
 
     override fun onConversationSynchronizationChange(conversation: Conversation?) {
         Log.d("TwilioInfo", "ChatListener.onConversationSynchronizationChange => conversation = '${conversation?.sid}' ")
-        sendEvent("channelSynchronizationChange", mapOf("channel" to Mapper.channelToMap(conversation!!)))
+        sendEvent("channelSynchronizationChange", mapOf("channel" to Mapper.channelToMap(pluginInstance, conversation!!)))
     }
 
     override fun onConnectionStateChange(connectionState: ConversationsClient.ConnectionState) {
@@ -27,11 +28,6 @@ class ChatListener(val properties: ConversationsClient.Properties) : Conversatio
     override fun onError(errorInfo: ErrorInfo) {
         sendEvent("error", null, errorInfo)
     }
-
-//    override fun onInvitedToChannelNotification(channelSid: String) {
-//        Log.d("TwilioInfo", "ChatListener.onInvitedToChannelNotification => channelSid = $channelSid")
-//        sendEvent("invitedToChannelNotification", mapOf("channelSid" to channelSid))
-//    }
 
     override fun onNewMessageNotification(channelSid: String?, messageSid: String?, messageIndex: Long) {
         Log.d("TwilioInfo", "ChatListener.onNewMessageNotification => channelSid = $channelSid, messageSid = $messageSid, messageIndex = $messageIndex")
@@ -81,7 +77,7 @@ class ChatListener(val properties: ConversationsClient.Properties) : Conversatio
     override fun onConversationUpdated(conversation: Conversation?, reason: Conversation.UpdateReason?) {
         Log.d("TwilioInfo", "ChatListener.onConversationUpdated => conversation '${conversation?.sid}' updated, $reason")
         sendEvent("channelUpdated", mapOf(
-                "channel" to Mapper.channelToMap(conversation!!),
+                "channel" to Mapper.channelToMap(pluginInstance, conversation!!),
                 "reason" to mapOf(
                     "type" to "channel",
                     "value" to reason.toString()
@@ -92,7 +88,7 @@ class ChatListener(val properties: ConversationsClient.Properties) : Conversatio
     override fun onConversationAdded(conversation: Conversation?) {
         Log.d("TwilioInfo", "ChatListener.onConversationAdded => conversation '${conversation?.sid}' added")
         sendEvent("channelAdded", mapOf(
-                "channel" to Mapper.channelToMap(conversation!!)
+                "channel" to Mapper.channelToMap(pluginInstance, conversation!!)
         ))
     }
 
@@ -110,7 +106,7 @@ class ChatListener(val properties: ConversationsClient.Properties) : Conversatio
     override fun onConversationDeleted(conversation: Conversation?) {
         Log.d("TwilioInfo", "ChatListener.onConversationDeleted => conversation '${conversation?.sid}' deleted")
         sendEvent("channelDeleted", mapOf(
-            "channel" to Mapper.channelToMap(conversation!!)
+            "channel" to Mapper.channelToMap(pluginInstance, conversation!!)
         ))
     }
 

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ChannelsMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ChannelsMethods.kt
@@ -10,15 +10,14 @@ import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 import android.util.Log
 
 object ChannelsMethods {
-
-    fun getChannel(call: MethodCall, result: MethodChannel.Result) {
+    fun getChannel(pluginInstance: TwilioConversationsPlugin, call: MethodCall, result: MethodChannel.Result) {
         val channelSidOrUniqueName = call.argument<String>("channelSidOrUniqueName")
                 ?: return result.error("ERROR", "Missing 'channelSidOrUniqueName'", null)
 
         TwilioConversationsPlugin.chatClient?.getConversation(channelSidOrUniqueName, object : CallbackListener<Conversation> {
             override fun onSuccess(newChannel: Conversation) {
                 Log.d("TwilioInfo", "ChannelsMethods.getChannel => onSuccess")
-                result.success(Mapper.channelToMap(newChannel))
+                result.success(Mapper.channelToMap(pluginInstance, newChannel))
             }
 
             override fun onError(errorInfo: ErrorInfo) {
@@ -36,14 +35,14 @@ object ChannelsMethods {
         result.success(TwilioConversationsPlugin.chatClient?.myConversations)
     }
 
-    fun createChannel(call: MethodCall, result: MethodChannel.Result) {
+    fun createChannel(pluginInstance: TwilioConversationsPlugin, call: MethodCall, result: MethodChannel.Result) {
         val friendlyName = call.argument<String>("friendlyName")
             ?: return result.error("ERROR", "Missing 'friendlyName'", null)
 
         TwilioConversationsPlugin.chatClient?.createConversation(friendlyName, object : CallbackListener<Conversation> {
             override fun onSuccess(newChannel: Conversation) {
                 Log.d("TwilioInfo", "ChannelsMethods.createChannel => onSuccess")
-                result.success(Mapper.channelToMap(newChannel))
+                result.success(Mapper.channelToMap(pluginInstance, newChannel))
             }
 
             override fun onError(errorInfo: ErrorInfo) {

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ChatClientMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ChatClientMethods.kt
@@ -28,6 +28,10 @@ object ChatClientMethods {
     fun shutdown(call: MethodCall, result: MethodChannel.Result) {
         return try {
             TwilioConversationsPlugin.chatClient?.shutdown()
+            TwilioConversationsPlugin.chatClient = null
+            TwilioConversationsPlugin.chatClientRegion = null
+            TwilioConversationsPlugin.chatClientDeferCA = null
+
             result.success(null)
         } catch (err: Exception) {
             result.error("ERROR", err.message, null)

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MemberMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MemberMethods.kt
@@ -10,14 +10,14 @@ import com.twilio.util.ErrorInfo
 import android.util.Log
 
 object MemberMethods {
-    fun getChannel(call: MethodCall, result: MethodChannel.Result) {
+    fun getChannel(pluginInstance: TwilioConversationsPlugin, call: MethodCall, result: MethodChannel.Result) {
         val channelSid = call.argument<String>("channelSid")
                 ?: return result.error("ERROR", "Missing 'channelSid'", null)
 
         TwilioConversationsPlugin.chatClient?.getConversation(channelSid, object : CallbackListener<Conversation> {
             override fun onSuccess(channel: Conversation) {
                 Log.d("TwilioInfo", "MemberMethods.getChannel => onSuccess")
-                result.success(Mapper.channelToMap(channel))
+                result.success(Mapper.channelToMap(pluginInstance, channel))
             }
 
             override fun onError(errorInfo: ErrorInfo) {

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MembersMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MembersMethods.kt
@@ -9,14 +9,14 @@ import com.twilio.util.ErrorInfo
 import android.util.Log
 
 object MembersMethods {
-    fun getChannel(call: MethodCall, result: MethodChannel.Result) {
+    fun getChannel(pluginInstance: TwilioConversationsPlugin, call: MethodCall, result: MethodChannel.Result) {
         val channelSid = call.argument<String>("channelSid")
                 ?: return result.error("ERROR", "Missing 'channelSid'", null)
 
         TwilioConversationsPlugin.chatClient?.getConversation(channelSid, object : CallbackListener<Conversation> {
             override fun onSuccess(channel: Conversation) {
                 Log.d("TwilioInfo", "MembersMethods.getChannel => onSuccess")
-                result.success(Mapper.channelToMap(channel))
+                result.success(Mapper.channelToMap(pluginInstance, channel))
             }
 
             override fun onError(errorInfo: ErrorInfo) {

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessageMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessageMethods.kt
@@ -10,14 +10,14 @@ import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 import android.util.Log
 
 object MessageMethods {
-    fun getChannel(call: MethodCall, result: MethodChannel.Result) {
+    fun getChannel(pluginInstance: TwilioConversationsPlugin, call: MethodCall, result: MethodChannel.Result) {
         val channelSid = call.argument<String>("channelSid")
                 ?: return result.error("ERROR", "Missing 'channelSid'", null)
 
         TwilioConversationsPlugin.chatClient?.getConversation(channelSid, object : CallbackListener<Conversation> {
             override fun onSuccess(channel: Conversation) {
                 Log.d("TwilioInfo", "MessageMethods.getChannel => onSuccess")
-                result.success(Mapper.channelToMap(channel))
+                result.success(Mapper.channelToMap(pluginInstance, channel))
             }
 
             override fun onError(errorInfo: ErrorInfo) {
@@ -136,7 +136,7 @@ object MessageMethods {
         val messageIndex = call.argument<Int>("messageIndex")?.toLong()
                 ?: return result.error("ERROR", "Missing 'messageIndex'", null)
 
-            TwilioConversationsPlugin.chatClient?.getConversation(channelSid, object : CallbackListener<Conversation> {
+        TwilioConversationsPlugin.chatClient?.getConversation(channelSid, object : CallbackListener<Conversation> {
                 override fun onSuccess(channel: Conversation) {
                     Log.d("TwilioInfo", "MessageMethods.getMedia => onSuccess")
                     channel.getMessageByIndex(messageIndex, object : CallbackListener<Message> {

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessagesMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessagesMethods.kt
@@ -10,14 +10,14 @@ import com.twilio.util.ErrorInfo
 import android.util.Log
 
 object MessagesMethods {
-    fun sendMessage(call: MethodCall, result: MethodChannel.Result) {
+    fun sendMessage(pluginInstance: TwilioConversationsPlugin, call: MethodCall, result: MethodChannel.Result) {
         val options = call.argument<Map<String, Any>>("options")
                 ?: return result.error("ERROR", "Missing 'options'", null)
         val channelSid = call.argument<String>("channelSid")
                 ?: return result.error("ERROR", "Missing 'channelSid'", null)
 
         Log.d("TwilioInfo", "MessagesMethods.sendMessage => started")
-        
+
         TwilioConversationsPlugin.chatClient?.getConversation(channelSid, object : CallbackListener<Conversation> {
             override fun onSuccess(channel: Conversation) {
                 Log.d("TwilioInfo", "MessagesMethods.sendMessage (Channels.getChannel) => onSuccess")
@@ -40,7 +40,7 @@ object MessagesMethods {
                             channel.prepareMessage().addMedia(FileInputStream(input), mimeType, "image.jpeg", object : MediaUploadListener {
                                 override fun onCompleted(mediaSid: String) {
                                     Log.d("TwilioInfo", "MessagesMethods.sendMessage (Message.addMedia) => onCompleted")
-                                    TwilioConversationsPlugin.mediaProgressSink?.success({
+                                    pluginInstance.mediaProgressSink?.success({
                                         "mediaProgressListenerId" to options["mediaProgressListenerId"]
                                         "name" to "completed"
                                         "data" to mediaSid
@@ -49,7 +49,7 @@ object MessagesMethods {
     
                                 override fun onStarted() {
                                     Log.d("TwilioInfo", "MessagesMethods.sendMessage (Message.addMedia) => onStarted")
-                                    TwilioConversationsPlugin.mediaProgressSink?.success({
+                                    pluginInstance.mediaProgressSink?.success({
                                         "mediaProgressListenerId" to options["mediaProgressListenerId"]
                                         "name" to "started"
                                     })        


### PR DESCRIPTION
Fix for #21. This is a bigger change, when Firebase Messaging receives a message while the app is terminated it starts up its own Flutter Engine. That creates an instance of this plugin, so when the app itself launches via the notification, another instance is created, but it skips the initialization step. Then when `create` (or any other method) is called, it throws a `MissingPluginException` because no `MethodCallHandler` was actually set up.