### PR TITLE
Fix for Web JS Mapper

### DIFF
--- a/flutter_twilio_conversations/CHANGELOG.md
+++ b/flutter_twilio_conversations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.02+12
+* WEB: Fixed issue with messages containing Media
+* Removed unnecessary logging operations
+
 ## 2.0.1+11
 * Fixed dependency implementations for android and ios
 

--- a/flutter_twilio_conversations/pubspec.yaml
+++ b/flutter_twilio_conversations/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_twilio_conversations_platform_interface: ^2.0.1
-  flutter_twilio_conversations_web: ^2.0.0
+  flutter_twilio_conversations_platform_interface: ^2.0.2
+  flutter_twilio_conversations_web: ^2.0.1
   enum_to_string: ^2.0.1
   intl: ^0.19.0
 

--- a/flutter_twilio_conversations_platform_interface/CHANGELOG.md
+++ b/flutter_twilio_conversations_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.2
+* Removed unnecessary logging operations
+  
 ## 2.0.1
 * Update README, add useful links to pubspec.yaml
 

--- a/flutter_twilio_conversations_platform_interface/pubspec.yaml
+++ b/flutter_twilio_conversations_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_twilio_conversations_platform_interface
 description: A common platform interface for the flutter_twilio_conversations plugin.
-version: 2.0.1
+version: 2.0.2
 repository: https://github.com/Diversido/flutter_twilio_conversations/tree/main/flutter_twilio_conversations_platform_interface
 issue_tracker: https://github.com/Diversido/flutter_twilio_conversations/issues
 

--- a/flutter_twilio_conversations_web/CHANGELOG.md
+++ b/flutter_twilio_conversations_web/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 2.0.1
+* Fixed issue with messages containing Media
+
 ## 2.0.0+10
 * First release of flutter_twilio_conversations web support

--- a/flutter_twilio_conversations_web/lib/methods/messages_methods.dart
+++ b/flutter_twilio_conversations_web/lib/methods/messages_methods.dart
@@ -49,6 +49,8 @@ class MessagesMethods {
 
       if ((messageOptions["body"]) != null) {
         messagePreparator.setBody(messageOptions["body"]);
+      } else {
+        messagePreparator.setBody('');
       }
 
       if (messageOptions["attributes"] != null) {

--- a/flutter_twilio_conversations_web/pubspec.yaml
+++ b/flutter_twilio_conversations_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_twilio_conversations_web
 description: Web platform implementation of flutter_twilio_conversations_web
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/Diversido/flutter_twilio_conversations/tree/main/flutter_twilio_conversations_web
 issue_tracker: https://github.com/Diversido/flutter_twilio_conversations/issues
 
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flutter_twilio_conversations_platform_interface: ^2.0.1
+  flutter_twilio_conversations_platform_interface: ^2.0.2
   meta: ^1.12.0
   js: ^0.6.4
   intl: ^0.19.0


### PR DESCRIPTION
A fix was implemented for the web js attributes mapper to handle all items in a lists instead of just fetching the first item in the list.