### PR TITLE
Web: Register and Unregister for push notifications

### DIFF
--- a/flutter_twilio_conversations/CHANGELOG.md
+++ b/flutter_twilio_conversations/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.4+14
+* INTERFACE: Added optional `webChannel` parameter to `registerForNotification` and `unregisterForNotification` methods
+* WEB: Added implementation for `registerForNotification` and `unregisterForNotification` methods
+* WEB: Update signatures for `tokenExpired` and `tokenAboutToExpire` events
+
 ## 2.0.3+13
 * WEB: Fixed JS Mapper - [#35](https://github.com/Diversido/flutter_twilio_conversations/issues/35)
 

--- a/flutter_twilio_conversations/lib/src/chat_client.dart
+++ b/flutter_twilio_conversations/lib/src/chat_client.dart
@@ -322,10 +322,17 @@ class ChatClient {
   ///
   /// Twilio iOS SDK handles receiving messages when app is in the background and displaying
   /// notifications.
-  Future<String> registerForNotification(String token) async {
+  ///
+  /// [webChannel] is only used for web notifications and it specifies
+  /// the channel type to use for web notifications.
+  Future<String> registerForNotification(
+    String token, {
+    WebNotificationsChannelType? webChannel,
+  }) async {
     try {
       final isInit = await FlutterTwilioConversationsPlatform.instance
-          .registerForNotification(token);
+          .registerForNotification(token,
+              webChannel: getNotificationChannel(webChannel));
       return isInit;
     } on PlatformException catch (err) {
       throw TwilioConversationsClient._convertException(err);
@@ -334,13 +341,31 @@ class ChatClient {
 
   /// Unregisters for push notifications.  Uses APNs on iOS and FCM on Android.
   ///
-  /// Token is only used on Android. iOS implementation retrieves APNs token itself.
-  Future<void> unregisterForNotification(String token) async {
+  /// Token is only used on Android/Web. iOS implementation retrieves APNs token itself.
+  ///
+  /// [webChannel] is only used for web notifications and it specifies the
+  /// channel type to use for unregistering web notifications.
+  Future<void> unregisterForNotification(
+    String token, {
+    WebNotificationsChannelType? webChannel,
+  }) async {
     try {
       await FlutterTwilioConversationsPlatform.instance
-          .unregisterForNotification(token);
+          .unregisterForNotification(token,
+              webChannel: getNotificationChannel(webChannel));
     } on PlatformException catch (err) {
       throw TwilioConversationsClient._convertException(err);
+    }
+  }
+
+  String? getNotificationChannel(WebNotificationsChannelType? webChannel) {
+    switch (webChannel) {
+      case WebNotificationsChannelType.fcm:
+        return 'fcm';
+      case WebNotificationsChannelType.apn:
+        return 'apn';
+      case null:
+        return null;
     }
   }
 
@@ -529,7 +554,8 @@ class ChatClient {
             users!.getUserById(userMap?['identity'])!, reason));
         break;
       default:
-        TwilioConversationsClient._log("Event '$eventName' not yet implemented");
+        TwilioConversationsClient._log(
+            "Event '$eventName' not yet implemented");
         break;
     }
   }

--- a/flutter_twilio_conversations/lib/src/parts.dart
+++ b/flutter_twilio_conversations/lib/src/parts.dart
@@ -39,3 +39,4 @@ part 'user.dart';
 part 'user_descriptor.dart';
 part 'user_update_reason.dart';
 part 'users.dart';
+part 'web_notifications_channel_type.dart';

--- a/flutter_twilio_conversations/lib/src/web_notifications_channel_type.dart
+++ b/flutter_twilio_conversations/lib/src/web_notifications_channel_type.dart
@@ -1,0 +1,3 @@
+part of flutter_twilio_conversations;
+
+enum WebNotificationsChannelType { fcm, apn }

--- a/flutter_twilio_conversations/pubspec.yaml
+++ b/flutter_twilio_conversations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_twilio_conversations
 description: Integrate the Twilio Conversations SDK with your Flutter app using this Twilio Conversations Flutter plugin
-version: 2.0.3+13
+version: 2.0.4+14
 repository: https://github.com/Diversido/flutter_twilio_conversations
 issue_tracker: https://github.com/Diversido/flutter_twilio_conversations/issues
 
@@ -11,8 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_twilio_conversations_platform_interface: ^2.0.2
-  flutter_twilio_conversations_web: ^2.0.2
+  flutter_twilio_conversations_platform_interface: ^2.0.4
+  flutter_twilio_conversations_web: ^2.0.4
   enum_to_string: ^2.0.1
   intl: ^0.19.0
 

--- a/flutter_twilio_conversations_platform_interface/CHANGELOG.md
+++ b/flutter_twilio_conversations_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.4
+* Added optional `webChannel` parameter to `registerForNotification` and `unregisterForNotification` methods
+
 ## 2.0.2
 * Removed unnecessary logging operations
   

--- a/flutter_twilio_conversations_platform_interface/lib/src/method_channel/method_channel_flutter_twilio_conversations.dart
+++ b/flutter_twilio_conversations_platform_interface/lib/src/method_channel/method_channel_flutter_twilio_conversations.dart
@@ -256,12 +256,18 @@ class MethodChannelFlutterTwilioConversations
     return await _methodChannel.invokeMethod('handleReceivedNotification');
   }
 
-  Future<String> registerForNotification(String token) async {
+  Future<String> registerForNotification(
+    String token, {
+    String? webChannel,
+  }) async {
     return await _methodChannel.invokeMethod(
         'registerForNotification', <String, Object>{'token': token});
   }
 
-  Future<void> unregisterForNotification(String token) async {
+  Future<void> unregisterForNotification(
+    String token, {
+    String? webChannel,
+  }) async {
     return await _methodChannel.invokeMethod(
         'unregisterForNotification', <String, Object>{'token': token});
   }

--- a/flutter_twilio_conversations_platform_interface/lib/src/platform_interface/flutter_twilio_conversations_platform.dart
+++ b/flutter_twilio_conversations_platform_interface/lib/src/platform_interface/flutter_twilio_conversations_platform.dart
@@ -230,12 +230,18 @@ abstract class FlutterTwilioConversationsPlatform extends PlatformInterface {
         'handleReceivedNotification() has not been implemented');
   }
 
-  Future<String> registerForNotification(String token) async {
+  Future<String> registerForNotification(
+    String token, {
+    String? webChannel,
+  }) async {
     throw UnimplementedError(
         'registerForNotification() has not been implemented');
   }
 
-  Future<void> unregisterForNotification(String token) async {
+  Future<void> unregisterForNotification(
+    String token, {
+    String? webChannel,
+  }) async {
     throw UnimplementedError(
         'unregisterForNotification() has not been implemented');
   }

--- a/flutter_twilio_conversations_platform_interface/pubspec.yaml
+++ b/flutter_twilio_conversations_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_twilio_conversations_platform_interface
 description: A common platform interface for the flutter_twilio_conversations plugin.
-version: 2.0.2
+version: 2.0.4
 repository: https://github.com/Diversido/flutter_twilio_conversations/tree/main/flutter_twilio_conversations_platform_interface
 issue_tracker: https://github.com/Diversido/flutter_twilio_conversations/issues
 

--- a/flutter_twilio_conversations_web/CHANGELOG.md
+++ b/flutter_twilio_conversations_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+* Added implementation for `registerForNotification` and `unregisterForNotification` methods
+* Update signatures for `tokenExpired` and `tokenAboutToExpire` events
+
 ## 2.0.3
 * Fixed JS Mapper - [#35](https://github.com/Diversido/flutter_twilio_conversations/issues/35)
 

--- a/flutter_twilio_conversations_web/lib/flutter_twilio_conversations_web.dart
+++ b/flutter_twilio_conversations_web/lib/flutter_twilio_conversations_web.dart
@@ -10,6 +10,7 @@ import 'package:flutter_twilio_conversations_web/methods/channel_methods.dart';
 import 'package:flutter_twilio_conversations_web/methods/channels_methods.dart';
 import 'package:flutter_twilio_conversations_web/methods/message_methods.dart';
 import 'package:flutter_twilio_conversations_web/methods/messages_methods.dart';
+import 'package:flutter_twilio_conversations_web/methods/notifications_methods.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 import 'listeners/channel_listener.dart';
@@ -299,18 +300,40 @@ class TwilioConversationsPlugin extends FlutterTwilioConversationsPlatform {
   }
 
   Future<void> handleReceivedNotification() async {
+    // This is a no-op for a method needed on iOS
     Logging.debug('handleReceivedNotification() has not been implemented');
     return null;
   }
 
-  Future<String> registerForNotification(String token) async {
-    Logging.debug('registerForNotification() has not been implemented');
-    return '';
+  Future<String> registerForNotification(
+    String token, {
+    String? webChannel,
+  }) async {
+    if (webChannel == null) {
+      Logging.debug(
+          'registerForNotification: webChannel is null, defaulting to fcm');
+    }
+    await NotificationsMethods().registerForNotification(
+      _chatClient,
+      token: token,
+      channel: webChannel ?? 'fcm',
+    );
+    return 'RegisterForNotification in Web';
   }
 
-  Future<void> unregisterForNotification(String token) async {
-    Logging.debug('unregisterForNotification() has not been implemented');
-    return null;
+  Future<void> unregisterForNotification(
+    String token, {
+    String? webChannel,
+  }) async {
+    if (webChannel == null) {
+      Logging.debug(
+          'unregisterForNotification: webChannel is null, defaulting to fcm');
+    }
+    return await NotificationsMethods().unregisterForNotification(
+      _chatClient,
+      token: token,
+      channel: webChannel ?? 'fcm',
+    );
   }
 
   @override

--- a/flutter_twilio_conversations_web/lib/interop/classes/client.dart
+++ b/flutter_twilio_conversations_web/lib/interop/classes/client.dart
@@ -22,4 +22,12 @@ class TwilioConversationsClient extends EventEmitter {
   external dynamic shutdown();
   external dynamic getConversationByUniqueName(String UniqueName);
   external dynamic getUser(String identity);
+  external dynamic setPushRegistrationId(
+    String channelType,
+    String registrationId,
+  );
+  external dynamic removePushRegistrations(
+    String channelType,
+    String registrationId,
+  );
 }

--- a/flutter_twilio_conversations_web/lib/interop/classes/push_notification.dart
+++ b/flutter_twilio_conversations_web/lib/interop/classes/push_notification.dart
@@ -1,0 +1,21 @@
+import 'package:js/js.dart';
+
+@JS('Twilio.Conversations.PushNotification')
+class PushNotification {
+  external String? action;
+  external int? badge;
+  external String? body;
+  external PushNotificationData? data;
+  external String? sound;
+  external String? title;
+
+  /// "twilio.conversations.new_message" | "twilio.conversations.added_to_conversation" | "twilio.conversations.removed_from_conversation"
+  external String? type;
+}
+
+@JS('Twilio.Conversations.PushNotificationData')
+class PushNotificationData {
+  external String? conversationSid;
+  external int? messageIndex;
+  external String? messageSid;
+}

--- a/flutter_twilio_conversations_web/lib/listeners/chat_listener.dart
+++ b/flutter_twilio_conversations_web/lib/listeners/chat_listener.dart
@@ -5,6 +5,7 @@ import 'package:flutter_twilio_conversations_web/interop/classes/channel.dart';
 import 'package:flutter_twilio_conversations_web/interop/classes/client.dart'
     as TwilioChatClient;
 import 'package:flutter_twilio_conversations_web/interop/classes/js_map.dart';
+import 'package:flutter_twilio_conversations_web/interop/classes/push_notification.dart';
 import 'package:flutter_twilio_conversations_web/listeners/base_listener.dart';
 import 'package:flutter_twilio_conversations_web/mapper.dart';
 import 'package:flutter_twilio_conversations_web/types/connection_state.dart';
@@ -36,6 +37,7 @@ class ChatClientEventListener extends BaseListener {
     _on('userSubscribed', userSubscribed);
     _on('userUnsubscribed', userUnsubscribed);
     _on('conversationUpdated', conversationUpdated);
+    _on('pushNotification', pushNotification);
   }
 
   void _on(String eventName, Function eventHandler) => _client.on(
@@ -176,7 +178,7 @@ class ChatClientEventListener extends BaseListener {
     );
   }
 
-  void tokenAboutToExpire(dynamic data) {
+  void tokenAboutToExpire() {
     debug('Token about to Expire ChatClient Event');
     sendEvent(
       'tokenAboutToExpire',
@@ -186,7 +188,7 @@ class ChatClientEventListener extends BaseListener {
     );
   }
 
-  void tokenExpired(dynamic data) {
+  void tokenExpired() {
     debug('Token Expired ChatClient Event');
     sendEvent(
       'tokenExpired',
@@ -236,6 +238,28 @@ class ChatClientEventListener extends BaseListener {
       null,
       e: data,
     );
+  }
+
+  void pushNotification(PushNotification pushNotification) {
+    debug('Push Notification ChatClient Event ${pushNotification.type}');
+
+    if (pushNotification.type == "twilio.conversations.new_message") {
+      sendEvent("newMessageNotification", {
+        "channelSid": pushNotification.data?.conversationSid,
+        "messageSid": pushNotification.data?.messageSid,
+        "messageIndex": pushNotification.data?.messageIndex,
+      });
+    } else if (pushNotification.type ==
+        "twilio.conversations.added_to_conversation") {
+      sendEvent("addedToChannelNotification", {
+        "channelSid": pushNotification.data?.conversationSid,
+      });
+    } else if (pushNotification.type ==
+        "twilio.conversations.removed_from_conversation") {
+      sendEvent("removedFromChannelNotification", {
+        "channelSid": pushNotification.data?.conversationSid,
+      });
+    }
   }
 
   sendEvent(String name, dynamic data, {ErrorInfo? e}) {

--- a/flutter_twilio_conversations_web/lib/methods/notifications_methods.dart
+++ b/flutter_twilio_conversations_web/lib/methods/notifications_methods.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_twilio_conversations_web/interop/classes/client.dart';
+import 'package:js/js_util.dart';
+
+class NotificationsMethods {
+  Future<void> registerForNotification(
+    TwilioConversationsClient? chatClient, {
+    required String channel,
+    required String token,
+  }) async {
+    await promiseToFuture<void>(
+      chatClient?.setPushRegistrationId(channel, token),
+    );
+  }
+
+  Future<void> unregisterForNotification(
+    TwilioConversationsClient? chatClient, {
+    required String channel,
+    required String token,
+  }) async {
+    await promiseToFuture<void>(
+      chatClient?.removePushRegistrations(channel, token),
+    );
+  }
+}

--- a/flutter_twilio_conversations_web/pubspec.yaml
+++ b/flutter_twilio_conversations_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_twilio_conversations_web
 description: Web platform implementation of flutter_twilio_conversations_web
-version: 2.0.3
+version: 2.0.4
 repository: https://github.com/Diversido/flutter_twilio_conversations/tree/main/flutter_twilio_conversations_web
 issue_tracker: https://github.com/Diversido/flutter_twilio_conversations/issues
 
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flutter_twilio_conversations_platform_interface: ^2.0.2
+  flutter_twilio_conversations_platform_interface: ^2.0.4
   meta: ^1.12.0
   js: ^0.6.4
   intl: ^0.19.0


### PR DESCRIPTION
- INTERFACE: Added optional `webChannel` parameter to `registerForNotification` and `unregisterForNotification` methods. Only used in the web implementation
- WEB: Added implementation for `registerForNotification` and `unregisterForNotification` methods
- WEB: Update signatures for `tokenExpired` and `tokenAboutToExpire` events