### PR TITLE
fix: Android - Fixed issue with advanceLastReadMessageIndexWithResult

### DIFF
--- a/flutter_twilio_conversations/CHANGELOG.md
+++ b/flutter_twilio_conversations/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.7+17
+* Android: Fixed issue [#39](https://github.com/Diversido/flutter_twilio_conversations/issues/39)
+
 ## 2.0.6+16
 * example: Add unread message count, send typing status when typing and added message indexes for debugging
 * WEB: Fix crash with `typing`, `getUnreadMessagesCount`, `connectionStateChanged` and `connectionError` methods

--- a/flutter_twilio_conversations/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessagesMethods.kt
+++ b/flutter_twilio_conversations/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessagesMethods.kt
@@ -299,7 +299,7 @@ object MessagesMethods {
     fun advanceLastReadMessageIndexWithResult(call: MethodCall, result: MethodChannel.Result) {
         val channelSid = call.argument<String>("channelSid")
                 ?: return result.error("ERROR", "Missing 'channelSid'", null)
-        val lastReadMessageIndex = call.argument<Long>("lastReadMessageIndex")
+        val lastReadMessageIndex = call.argument<Int>("lastReadMessageIndex")
                 ?: return result.error("ERROR", "Missing 'lastReadMessageIndex'", null)
 
         TwilioConversationsPlugin.chatClient?.getConversation(channelSid, object : CallbackListener<Conversation> {

--- a/flutter_twilio_conversations/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessagesMethods.kt
+++ b/flutter_twilio_conversations/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessagesMethods.kt
@@ -299,7 +299,7 @@ object MessagesMethods {
     fun advanceLastReadMessageIndexWithResult(call: MethodCall, result: MethodChannel.Result) {
         val channelSid = call.argument<String>("channelSid")
                 ?: return result.error("ERROR", "Missing 'channelSid'", null)
-        val lastReadMessageIndex = call.argument<Int>("lastReadMessageIndex")
+        val lastReadMessageIndex = call.argument<Int>("lastReadMessageIndex")?.toLong()
                 ?: return result.error("ERROR", "Missing 'lastReadMessageIndex'", null)
 
         TwilioConversationsPlugin.chatClient?.getConversation(channelSid, object : CallbackListener<Conversation> {

--- a/flutter_twilio_conversations/pubspec.yaml
+++ b/flutter_twilio_conversations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_twilio_conversations
 description: Integrate the Twilio Conversations SDK with your Flutter app using this Twilio Conversations Flutter plugin
-version: 2.0.6+16
+version: 2.0.7+17
 repository: https://github.com/Diversido/flutter_twilio_conversations
 issue_tracker: https://github.com/Diversido/flutter_twilio_conversations/issues
 
@@ -11,8 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_twilio_conversations_platform_interface: ^2.0.6
-  flutter_twilio_conversations_web: ^2.0.6
+  flutter_twilio_conversations_platform_interface: ^2.0.7
+  flutter_twilio_conversations_web: ^2.0.7
   enum_to_string: ^2.0.1
   intl: ^0.19.0
 

--- a/flutter_twilio_conversations_platform_interface/pubspec.yaml
+++ b/flutter_twilio_conversations_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_twilio_conversations_platform_interface
 description: A common platform interface for the flutter_twilio_conversations plugin.
-version: 2.0.6
+version: 2.0.7
 repository: https://github.com/Diversido/flutter_twilio_conversations/tree/main/flutter_twilio_conversations_platform_interface
 issue_tracker: https://github.com/Diversido/flutter_twilio_conversations/issues
 

--- a/flutter_twilio_conversations_web/pubspec.yaml
+++ b/flutter_twilio_conversations_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_twilio_conversations_web
 description: Web platform implementation of flutter_twilio_conversations_web
-version: 2.0.6
+version: 2.0.7
 repository: https://github.com/Diversido/flutter_twilio_conversations/tree/main/flutter_twilio_conversations_web
 issue_tracker: https://github.com/Diversido/flutter_twilio_conversations/issues
 
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flutter_twilio_conversations_platform_interface: ^2.0.6
+  flutter_twilio_conversations_platform_interface: ^2.0.7
   meta: ^1.12.0
   js: ^0.6.4
   intl: ^0.19.0


### PR DESCRIPTION
Fixes #39 

* [`flutter_twilio_conversations/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessagesMethods.kt`](diffhunk://#diff-e6637eb3bff60933e736a6edd9efe0988cb50596c62cacbd85c8a98f3ebbba88L302-R302): Changed the data type of `lastReadMessageIndex` from `Long` to `Int` in the `advanceLastReadMessageIndexWithResult` method.
