### PR TITLE
fix: Various Android and Web fixes

### DIFF
--- a/flutter_twilio_conversations/CHANGELOG.md
+++ b/flutter_twilio_conversations/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.0.9+19
+
+### Android
+* Fixed issue [#42](https://github.com/Diversido/flutter_twilio_conversations/issues/42) related to `setNoMessagesReadWithResult`
+* Fixed issue [#45](https://github.com/Diversido/flutter_twilio_conversations/issues/45) related to the namespace in Gradle builds
+* Updated Twilio Conversations Android SDK to [6.1.1](https://www.twilio.com/docs/conversations/android/changelog#conversations-611-september-2-2024)
+
+### Web
+* Fixed crash in `unregisterForNotification` if the token is empty
+* example: Updated index.html to use the latest Twilio Conversations JavaScript SDK [2.6.1](https://www.twilio.com/docs/conversations/javascript/changelog#conversations-261-february-17-2025)
+
+### General
+* Fixed issue [#44](https://github.com/Diversido/flutter_twilio_conversations/issues/44) related to `getMembersList`
+
 ## 2.0.8+18
 * Fixed issue [#41](https://github.com/Diversido/flutter_twilio_conversations/issues/41)
  

--- a/flutter_twilio_conversations/android/build.gradle
+++ b/flutter_twilio_conversations/android/build.gradle
@@ -2,7 +2,7 @@ group 'twilio.flutter.flutter_twilio_conversations'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'twilio.flutter.flutter_twilio_conversations'
+
     compileSdkVersion 33
 
     sourceSets {
@@ -45,5 +47,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation 'com.twilio:conversations-android:6.0.3'
+    implementation 'com.twilio:conversations-android:6.1.1'
 }

--- a/flutter_twilio_conversations/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessagesMethods.kt
+++ b/flutter_twilio_conversations/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessagesMethods.kt
@@ -362,10 +362,10 @@ object MessagesMethods {
             override fun onSuccess(channel: Conversation) {
                 Log.d("TwilioInfo", "MessagesMethods.setNoMessagesReadWithResult (Channels.getChannel) => onSuccess")
 
-                channel.setAllMessagesUnread(object : CallbackListener<Long> {
-                    override fun onSuccess(index: Long) {
+                channel.setAllMessagesUnread(object : CallbackListener<Long?> {
+                    override fun onSuccess(index: Long?) {
                         Log.d("TwilioInfo", "MessagesMethods.setNoMessagesReadWithResult (Message.setNoMessagesReadWithResult) => onSuccess: $index")
-                        result.success(index)
+                        result.success(index ?: 0L)
                     }
 
                     override fun onError(errorInfo: ErrorInfo) {

--- a/flutter_twilio_conversations/example/android/build.gradle
+++ b/flutter_twilio_conversations/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()

--- a/flutter_twilio_conversations/example/ios/Podfile.lock
+++ b/flutter_twilio_conversations/example/ios/Podfile.lock
@@ -6,30 +6,28 @@ PODS:
     - Flutter
   - flutter_twilio_conversations (0.0.1):
     - Flutter
-    - TwilioConversationsClient (~> 3.1.0)
+    - TwilioConversationsClient (~> 4.0.2)
   - fluttertoast (0.0.2):
     - Flutter
     - Toast
-  - FMDB (2.7.5):
-    - FMDB/standard (= 2.7.5)
-  - FMDB/standard (2.7.5)
   - image_picker_ios (0.0.1):
     - Flutter
-  - path_provider_ios (0.0.1):
+  - path_provider_foundation (0.0.1):
     - Flutter
+    - FlutterMacOS
   - "permission_handler (5.1.0+2)":
     - Flutter
-  - sqflite (0.0.2):
+  - sqflite_darwin (0.0.4):
     - Flutter
-    - FMDB (>= 2.7.5)
+    - FlutterMacOS
   - Toast (4.0.0)
-  - TwilioCommonLib (2.0.0)
-  - TwilioConversationsClient (3.1.0):
-    - TwilioTwilsockLib (= 2.0.0)
-  - TwilioStateMachine (2.0.0)
-  - TwilioTwilsockLib (2.0.0):
-    - TwilioCommonLib (= 2.0.0)
-    - TwilioStateMachine (= 2.0.0)
+  - TwilioCommonLib (2.0.2)
+  - TwilioConversationsClient (4.0.2):
+    - TwilioTwilsockLib (= 2.0.2)
+  - TwilioStateMachine (2.0.2)
+  - TwilioTwilsockLib (2.0.2):
+    - TwilioCommonLib (= 2.0.2)
+    - TwilioStateMachine (= 2.0.2)
 
 DEPENDENCIES:
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
@@ -38,13 +36,12 @@ DEPENDENCIES:
   - flutter_twilio_conversations (from `.symlinks/plugins/flutter_twilio_conversations/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
-  - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
-  - sqflite (from `.symlinks/plugins/sqflite/ios`)
+  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
 
 SPEC REPOS:
   trunk:
-    - FMDB
     - Toast
     - TwilioCommonLib
     - TwilioConversationsClient
@@ -64,30 +61,29 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/fluttertoast/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
-  path_provider_ios:
-    :path: ".symlinks/plugins/path_provider_ios/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler:
     :path: ".symlinks/plugins/permission_handler/ios"
-  sqflite:
-    :path: ".symlinks/plugins/sqflite/ios"
+  sqflite_darwin:
+    :path: ".symlinks/plugins/sqflite_darwin/darwin"
 
 SPEC CHECKSUMS:
-  device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
-  flutter_twilio_conversations: 89f406e50f0dfa3bb6848926b724045bc5eae097
-  fluttertoast: 16fbe6039d06a763f3533670197d01fc73459037
-  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
-  image_picker_ios: b786a5dcf033a8336a657191401bfdf12017dabb
-  path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
+  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
+  flutter_twilio_conversations: def0840c841d6c478ef01468af027dd41b3294c5
+  fluttertoast: e9a18c7be5413da53898f660530c56f35edfba9c
+  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
-  sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
+  sqflite_darwin: a553b1fd6fe66f53bbb0fe5b4f5bab93f08d7a13
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
-  TwilioCommonLib: 2e02cbe30a66ab1da37be9550ea144ec3589cebd
-  TwilioConversationsClient: 8bf5deae1856a3eb7eb300357054fe1552e5494b
-  TwilioStateMachine: d94358d9ceec243aa12fd4160048c40ce4afc172
-  TwilioTwilsockLib: 06086e8e9fb45fb41a2311b83f9e059c6a70b09b
+  TwilioCommonLib: cd0b6ced22d1a9a6fc9df813bd03aff113ceb91c
+  TwilioConversationsClient: 892799e4a794cc3edc112594c0c7f03fc447e776
+  TwilioStateMachine: 83d99bcb38d6133dd4f01f87464bd297f9f6c41b
+  TwilioTwilsockLib: 2ac549121dddaafdd24e36f3a44b2b14eff7f540
 
 PODFILE CHECKSUM: 1b645128cb8540ffbdbe1df107e873dd4abfccbd
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.15.2

--- a/flutter_twilio_conversations/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/flutter_twilio_conversations/example/ios/Runner.xcodeproj/project.pbxproj
@@ -254,15 +254,14 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/FMDB/FMDB.framework",
 				"${BUILT_PRODUCTS_DIR}/Toast/Toast.framework",
 				"${BUILT_PRODUCTS_DIR}/device_info_plus/device_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_local_notifications/flutter_local_notifications.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_twilio_conversations/flutter_twilio_conversations.framework",
 				"${BUILT_PRODUCTS_DIR}/fluttertoast/fluttertoast.framework",
 				"${BUILT_PRODUCTS_DIR}/image_picker_ios/image_picker_ios.framework",
-				"${BUILT_PRODUCTS_DIR}/path_provider_ios/path_provider_ios.framework",
-				"${BUILT_PRODUCTS_DIR}/sqflite/sqflite.framework",
+				"${BUILT_PRODUCTS_DIR}/path_provider_foundation/path_provider_foundation.framework",
+				"${BUILT_PRODUCTS_DIR}/sqflite_darwin/sqflite_darwin.framework",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/TwilioCommonLib/TwilioCommonLib.framework/TwilioCommonLib",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/TwilioConversationsClient/TwilioConversationsClient.framework/TwilioConversationsClient",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/TwilioStateMachine/TwilioStateMachine.framework/TwilioStateMachine",
@@ -270,15 +269,14 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FMDB.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Toast.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/device_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_local_notifications.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_twilio_conversations.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/fluttertoast.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/image_picker_ios.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_ios.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqflite.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_foundation.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqflite_darwin.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwilioCommonLib.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwilioConversationsClient.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TwilioStateMachine.framework",

--- a/flutter_twilio_conversations/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/flutter_twilio_conversations/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/flutter_twilio_conversations/example/ios/Runner/AppDelegate.swift
+++ b/flutter_twilio_conversations/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/flutter_twilio_conversations/example/lib/redux/effects/subscriptions_middleware.dart
+++ b/flutter_twilio_conversations/example/lib/redux/effects/subscriptions_middleware.dart
@@ -38,19 +38,14 @@ class MessengerSubscriptionsMiddleware extends MiddlewareClass<AppState> {
             (event == ChatClientSynchronizationStatus.COMPLETED &&
                 store.state.chatClient?.channels != null)) {
           final dialogs = store.state.chatClient!.channels!.subscribedChannels
-              .map(
-                (channel) => ConversationDialog(
-                  channel: channel,
-                  name: channel.sid,
-                ),
-              )
-              .toList();
+              .map((channel) {
+            return ConversationDialog(
+              channel: channel,
+              name: channel.sid,
+            );
+          }).toList();
 
-          store.dispatch(
-            UpdateDialogsAction(
-              dialogs,
-            ),
-          );
+          store.dispatch(UpdateDialogsAction(dialogs));
 
           for (var conversation
               in store.state.chatClient!.channels!.subscribedChannels) {
@@ -58,6 +53,10 @@ class MessengerSubscriptionsMiddleware extends MiddlewareClass<AppState> {
             store.dispatch(
                 GetConversationUnreadMessagesCountAction(conversation));
             store.dispatch(SubscribeToMembersTypingStatus(conversation));
+
+            //Only for example purposes, print members
+            final members = await conversation.members?.getMembersList();
+            debugPrint('Got members: ${members?.length}');
           }
 
           store.dispatch(

--- a/flutter_twilio_conversations/example/lib/redux/effects/subscriptions_middleware.dart
+++ b/flutter_twilio_conversations/example/lib/redux/effects/subscriptions_middleware.dart
@@ -38,12 +38,19 @@ class MessengerSubscriptionsMiddleware extends MiddlewareClass<AppState> {
             (event == ChatClientSynchronizationStatus.COMPLETED &&
                 store.state.chatClient?.channels != null)) {
           final dialogs = store.state.chatClient!.channels!.subscribedChannels
-              .map((channel) {
-            return ConversationDialog(
-              channel: channel,
-              name: channel.sid,
-            );
-          }).toList();
+              .map(
+                (channel) => ConversationDialog(
+                  channel: channel,
+                  name: channel.sid,
+                ),
+              )
+              .toList();
+
+          store.dispatch(
+            UpdateDialogsAction(
+              dialogs,
+            ),
+          );
 
           store.dispatch(UpdateDialogsAction(dialogs));
 

--- a/flutter_twilio_conversations/example/lib/redux/effects/subscriptions_middleware.dart
+++ b/flutter_twilio_conversations/example/lib/redux/effects/subscriptions_middleware.dart
@@ -52,8 +52,6 @@ class MessengerSubscriptionsMiddleware extends MiddlewareClass<AppState> {
             ),
           );
 
-          store.dispatch(UpdateDialogsAction(dialogs));
-
           for (var conversation
               in store.state.chatClient!.channels!.subscribedChannels) {
             store.dispatch(GetConversationMessagesAction(conversation));

--- a/flutter_twilio_conversations/example/web/index.html
+++ b/flutter_twilio_conversations/example/web/index.html
@@ -37,8 +37,8 @@
     // The value below is injected by flutter build, do not touch.
     const serviceWorkerVersion = null;
   </script>
-  <script src="https://sdk.twilio.com/js/conversations/releases/2.5.0/twilio-conversations.min.js"
-    integrity="sha256-aBKm/Hjylgtmr/XtFMSDbUWf+2VlRHBbj4jdgy/KhRc=" crossorigin="anonymous"></script>
+  <script src="https://sdk.twilio.com/js/conversations/releases/2.6.1/twilio-conversations.min.js"
+   integrity="sha256-dvIsyBhuA90h9qTVN37CZ1kLwp+JZRqeV/lxv8X0SoA="crossorigin="anonymous"></script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer></script>
 </head>

--- a/flutter_twilio_conversations/ios/.gitignore
+++ b/flutter_twilio_conversations/ios/.gitignore
@@ -35,3 +35,5 @@ Icon?
 
 /Flutter/Generated.xcconfig
 /Flutter/flutter_export_environment.sh
+
+.build

--- a/flutter_twilio_conversations/lib/src/attributes.dart
+++ b/flutter_twilio_conversations/lib/src/attributes.dart
@@ -12,11 +12,11 @@ class Attributes {
 
   Attributes(this._type, this._json);
 
-  factory Attributes.fromMap(Map<String, dynamic> map) {
-    final type =
-        EnumToString.fromString(AttributesType.values, map['type'] ?? 'null') ??
-            AttributesType.NULL;
-    return Attributes(type, map['data'] ?? '');
+  factory Attributes.fromMap(Map<String, dynamic>? map) {
+    final type = EnumToString.fromString(
+            AttributesType.values, map?['type'] ?? 'null') ??
+        AttributesType.NULL;
+    return Attributes(type, map?['data'] ?? '');
   }
 
   Map<String, dynamic>? getJSONObject() {

--- a/flutter_twilio_conversations/lib/src/member.dart
+++ b/flutter_twilio_conversations/lib/src/member.dart
@@ -68,7 +68,7 @@ class Member {
       map['sid'],
       EnumToString.fromString(MemberType.values, map['type'])!,
       map['channelSid'],
-      Attributes.fromMap(map['attributes'].cast<String, dynamic>()),
+      Attributes.fromMap(map['attributes']?.cast<String, dynamic>()),
     );
     member._updateFromMap(map);
     return member;

--- a/flutter_twilio_conversations/lib/src/members.dart
+++ b/flutter_twilio_conversations/lib/src/members.dart
@@ -19,7 +19,7 @@ class Members {
   Future<List<Member>?> getMembersList() async {
     final membersListData = await FlutterTwilioConversationsPlatform.instance
         .getMembersList(_channelSid);
-    if (membersListData['membersList'] != null) {
+    if (membersListData?['membersList'] != null) {
       return membersListData['membersList']
           .map<Member>((m) => Member._fromMap(m.cast<String, dynamic>()))
           .toList();

--- a/flutter_twilio_conversations/pubspec.yaml
+++ b/flutter_twilio_conversations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_twilio_conversations
 description: Integrate the Twilio Conversations SDK with your Flutter app using this Twilio Conversations Flutter plugin
-version: 2.0.8+18
+version: 2.0.9+19
 repository: https://github.com/Diversido/flutter_twilio_conversations
 issue_tracker: https://github.com/Diversido/flutter_twilio_conversations/issues
 
@@ -11,8 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_twilio_conversations_platform_interface: ^2.0.8
-  flutter_twilio_conversations_web: ^2.0.8
+  flutter_twilio_conversations_platform_interface: ^2.0.9
+  flutter_twilio_conversations_web: ^2.0.9
   enum_to_string: ^2.0.1
   intl: ^0.19.0
 

--- a/flutter_twilio_conversations/test/member_test.dart
+++ b/flutter_twilio_conversations/test/member_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_twilio_conversations/flutter_twilio_conversations.dart';
+
+void main() {
+  setUpAll(() {});
+
+  group('.fromMap()', () {
+    test('should return null when map is null', () {
+      final member = Member.fromMap(null);
+      expect(member, isNull);
+    });
+
+    test('should create a valid Member from a complete map', () {
+      final input = {
+        'sid': 'SM123',
+        'type': 'chat',
+        'channelSid': 'CH123',
+        'attributes': {'key': 'value'},
+        'lastReadMessageIndex': 5,
+        'lastConsumptionTimestamp': '2023-10-05T12:00:00Z',
+        'identity': 'user1',
+      };
+
+      final member = Member.fromMap(input);
+      expect(member, isNotNull);
+      expect(member!.sid, equals('SM123'));
+      expect(member.type.toString().toLowerCase(), contains('chat'));
+      expect(member.attributes, isNotNull);
+      expect(member.lastReadMessageIndex, equals(5));
+      expect(member.lastConsumptionTimestamp, equals('2023-10-05T12:00:00Z'));
+      expect(member.identity, equals('user1'));
+    });
+
+    test('should create a valid Member from with no attributes', () {
+      final input = {
+        'sid': 'SM123',
+        'type': 'chat',
+        'channelSid': 'CH123',
+        'lastReadMessageIndex': 5,
+        'lastConsumptionTimestamp': '2023-10-05T12:00:00Z',
+        'identity': 'user1',
+      };
+
+      final member = Member.fromMap(input);
+      expect(member, isNotNull);
+      expect(member!.sid, equals('SM123'));
+      expect(member.type.toString().toLowerCase(), contains('chat'));
+      expect(member.attributes!.type, AttributesType.NULL);
+      expect(member.attributes!.getJSONArray(), null);
+      expect(member.lastReadMessageIndex, equals(5));
+      expect(member.lastConsumptionTimestamp, equals('2023-10-05T12:00:00Z'));
+      expect(member.identity, equals('user1'));
+    });
+  });
+}

--- a/flutter_twilio_conversations/test/member_test.dart
+++ b/flutter_twilio_conversations/test/member_test.dart
@@ -31,7 +31,7 @@ void main() {
       expect(member.identity, equals('user1'));
     });
 
-    test('should create a valid Member from with no attributes', () {
+    test('should create a valid Member from a map with no attributes', () {
       final input = {
         'sid': 'SM123',
         'type': 'chat',

--- a/flutter_twilio_conversations_platform_interface/pubspec.yaml
+++ b/flutter_twilio_conversations_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_twilio_conversations_platform_interface
 description: A common platform interface for the flutter_twilio_conversations plugin.
-version: 2.0.8
+version: 2.0.9
 repository: https://github.com/Diversido/flutter_twilio_conversations/tree/main/flutter_twilio_conversations_platform_interface
 issue_tracker: https://github.com/Diversido/flutter_twilio_conversations/issues
 

--- a/flutter_twilio_conversations_web/CHANGELOG.md
+++ b/flutter_twilio_conversations_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.9
+* Fix crash with `unregisterForNotification` if the token is empty
+* Update example to use the latest Twilio Conversations JavaScript SDK [2.6.1](https://sdk.twilio.com/js/conversations/releases/2.6.1/docs/index.html)
+
 ## 2.0.6
 * Fix crash with `typing`, `getUnreadMessagesCount`, `connectionStateChanged` and `connectionError` methods
 * Refactored `sendMessage` to improve stability during conversation creation

--- a/flutter_twilio_conversations_web/lib/methods/notifications_methods.dart
+++ b/flutter_twilio_conversations_web/lib/methods/notifications_methods.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_twilio_conversations_web/interop/classes/client.dart';
+import 'package:flutter_twilio_conversations_web/logging.dart';
 import 'package:js/js_util.dart';
 
 class NotificationsMethods {
@@ -17,6 +18,11 @@ class NotificationsMethods {
     required String channel,
     required String token,
   }) async {
+    if (token.isEmpty) {
+      Logging.debug('error: the parameter "token" was not given');
+      return;
+    }
+
     await promiseToFuture<void>(
       chatClient?.removePushRegistrations(channel, token),
     );

--- a/flutter_twilio_conversations_web/pubspec.yaml
+++ b/flutter_twilio_conversations_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_twilio_conversations_web
 description: Web platform implementation of flutter_twilio_conversations_web
-version: 2.0.8
+version: 2.0.9
 repository: https://github.com/Diversido/flutter_twilio_conversations/tree/main/flutter_twilio_conversations_web
 issue_tracker: https://github.com/Diversido/flutter_twilio_conversations/issues
 
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flutter_twilio_conversations_platform_interface: ^2.0.8
+  flutter_twilio_conversations_platform_interface: ^2.0.9
   meta: ^1.12.0
   js: ^0.6.4
   intl: ^0.19.0


### PR DESCRIPTION
# Summary
- Fixes #42 
- Fixes #44 
- Fixes #45 
- Fixes `unregisterForNotification` on web if no token is provided
- Update Android Twilio SDK
- Update example web Twilio SDK

### Dependency Updates:
* Upgraded Kotlin version from `1.8.0` to `1.9.10` in `flutter_twilio_conversations/android/build.gradle` and `flutter_twilio_conversations/example/android/build.gradle`. [[1]](diffhunk://#diff-1cf91d741376aaeb5203b82be3b54e9b14ac4d9f1f0840d8a78b6cd45bb390b2L5-R5) [[2]](diffhunk://#diff-923dac263922873a8393fbfa9919ac72c86defbcd370c57dc4f625454fd034e4L2-R2)
* Updated `com.twilio:conversations-android` dependency from `6.0.3` to `6.1.1` in `flutter_twilio_conversations/android/build.gradle`.
* Updated Twilio Conversations JavaScript SDK from `2.5.0` to `2.6.1` in `flutter_twilio_conversations/example/web/index.html`.

### Code Improvements:
* Added `namespace` to `android` block in `flutter_twilio_conversations/android/build.gradle`.
* Refactored `MessagesMethods.kt` to handle nullable `Long` type in `setAllMessagesUnread` callback.
* Improved null safety in various files (`attributes.dart`, `member.dart`, `members.dart`). [[1]](diffhunk://#diff-7d380d7d8923e0b8d764be7647dfa3358245d7d46b048e78c8e9dbb6269904f1L15-R19) [[2]](diffhunk://#diff-f8c4cd68b49f8666a8e9579da771397aec9d073d7159ccea0062f19e5473ea3dL71-R71) [[3]](diffhunk://#diff-9496b55da0a0423991b3804c0c7bf9736ee8a7a2752365349c2c117eef7e4a54L22-R22)
* Added logging and validation for empty tokens in `notifications_methods.dart`. [[1]](diffhunk://#diff-80ea746aefcb76dee553d95396ab4d6ba0e93e8c8fc02978883e8d988dd73dffR2) [[2]](diffhunk://#diff-80ea746aefcb76dee553d95396ab4d6ba0e93e8c8fc02978883e8d988dd73dffR21-R25)

### Test Additions:
* Added unit tests for `Member.fromMap` method in `flutter_twilio_conversations/test/member_test.dart`.

These changes collectively enhance the stability, safety, and functionality of the `flutter_twilio_conversations` package.